### PR TITLE
Simplify Blueprint Resources by Removing Individual Blueprint Endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.5] - 2025-03-21
+## [0.1.5] - 2025-03-21
 
 ### Removed
 - Removed individual blueprint endpoints (`port-blueprint://` and `port-blueprint-summary://`) as they weren't effectively accessible through eMCP, making them redundant
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved documentation clarity for remaining blueprint endpoints
 - Streamlined resource patterns documentation
 
-## [0.0.4] - 2025-03-20
+## [0.1.4] - 2025-03-20
 
 ### Added
 - New `get_blueprint` tool to retrieve detailed information about specific blueprints
@@ -24,12 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added corresponding Port resources for blueprint operations
 - Improved code organization and structure through refactoring
 
-## [0.0.3] - 2025-03-17
+## [0.1.3] - 2025-03-17
 
 ### Fixed
 - Fixed compatibility issue with Port API changes in AI agent response handling
 
-## [0.0.2] - 2025-03-06
+## [0.1.2] - 2025-03-06
 
 ### Changed
 - Migrated to PyPort SDK for improved authentication and extensibility
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration with PyPort SDK for better API interaction
 - Simplified authentication process
 
-## [0.0.1] - 2025-03-05
+## [0.1.1] - 2025-03-05
 
 ### Added
 - Initial release of the Port MCP server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5] - 2025-03-21
+
+### Removed
+- Removed individual blueprint endpoints (`port-blueprint://` and `port-blueprint-summary://`) as they weren't effectively accessible through eMCP, making them redundant
+- Removed `_get_blueprint()` helper function as it's no longer needed
+
+### Changed
+- Simplified blueprint resources to focus on list-based endpoints only
+- Improved documentation clarity for remaining blueprint endpoints
+- Streamlined resource patterns documentation
+
 ## [0.0.4] - 2025-03-20
 
 ### Added

--- a/src/mcp_server_port/prompts/default_prompt.py
+++ b/src/mcp_server_port/prompts/default_prompt.py
@@ -41,10 +41,8 @@ Tools:
   - Try other tools if this doesn't provide desired results
 
 Resource patterns:
-- port-blueprints: - List of all blueprints (summary)
-- port-blueprints-detailed: - List of all blueprints (detailed)
-- port-blueprint://{blueprint_identifier} - Specific blueprint (detailed)
-- port-blueprint-summary://{blueprint_identifier} - Specific blueprint (summary)
+- port-blueprints: - Summarized list of all blueprints
+- port-blueprints-detailed: - Detailed list of all blueprints (with schema properties and relations)
 
 Note: While tools offer parameter flexibility, resources provide fixed formats with dedicated endpoints.
 """

--- a/src/mcp_server_port/resources/blueprint_resources.py
+++ b/src/mcp_server_port/resources/blueprint_resources.py
@@ -14,29 +14,17 @@ def register(mcp: FastMCP, port_client: Any) -> None:
     Args:
         mcp: The FastMCP server instance
         port_client: The Port client instance
-        
-    Note on Blueprint Format:
-        Resources are available in two formats with separate endpoints:
-        - Summary format: Basic information only (title, identifier, description)
-        - Detailed format: Full information including schema properties and relations
-        
-        Available endpoints:
-        - port-blueprints: - List of all blueprints in summary format
-        - port-blueprints-detailed: - List of all blueprints in detailed format
-        - port-blueprint://{blueprint_identifier} - Specific blueprint in detailed format
-        - port-blueprint-summary://{blueprint_identifier} - Specific blueprint in summary format
+
+    Available endpoints:
+    - port-blueprints: - List of all blueprints in summary format (title, identifier, description)
+    - port-blueprints-detailed: - List of all blueprints in detailed format (title, identifier, description, schema properties, and relations)
     """
     
     async def _get_all_blueprints(detailed: bool = False) -> str:
         logger.info(f"Resource: Retrieving all blueprints from Port (detailed={detailed})")
         blueprints = await port_client.get_blueprints()
         return blueprints.to_text(detailed=detailed) if hasattr(blueprints, 'to_text') else str(blueprints)
-    
-    async def _get_blueprint(blueprint_identifier: str, detailed: bool = False) -> str:
-        logger.info(f"Resource: Retrieving blueprint with identifier: {blueprint_identifier} (detailed={detailed})")
-        blueprint = await port_client.get_blueprint(blueprint_identifier)
-        return blueprint.to_text(detailed=detailed) if hasattr(blueprint, 'to_text') else str(blueprint)
-    
+       
     @mcp.resource("port-blueprints:")
     async def get_all_blueprints_summary() -> str:
         """
@@ -60,55 +48,12 @@ def register(mcp: FastMCP, port_client: Any) -> None:
         
         Returns:
             A formatted text representation of all blueprints in detailed format, including:
-            - Title and identifier for each blueprint
-            - Description (if available)
+            - Title, identifier, description for each blueprint
             - Schema properties with titles, types, and formats
             - Relations with target blueprints and cardinality
-            - Creation/update timestamps (if available)
         """
         try:
             return await _get_all_blueprints(detailed=True)
         except Exception as e:
             logger.error(f"Error in get_all_blueprints_detailed resource: {str(e)}", exc_info=True)
             return f"❌ Error retrieving detailed blueprints: {str(e)}"
-
-    @mcp.resource("port-blueprint://{blueprint_identifier}")
-    async def get_specific_blueprint(blueprint_identifier: str) -> str:
-        """
-        Get detailed information about a specific blueprint.
-        
-        Path parameters:
-            blueprint_identifier: The unique identifier of the blueprint
-            
-        Returns:
-            A formatted text representation of the blueprint in detailed format, including:
-            - Title and identifier
-            - Description (if available)
-            - Schema properties with titles, types, and formats
-            - Relations with target blueprints and cardinality
-            - Creation/update timestamps (if available)
-        """
-        try:
-            return await _get_blueprint(blueprint_identifier, detailed=True)
-        except Exception as e:
-            logger.error(f"Error in get_specific_blueprint resource: {str(e)}", exc_info=True)
-            return f"❌ Error retrieving blueprint {blueprint_identifier}: {str(e)}"
-
-    @mcp.resource("port-blueprint-summary://{blueprint_identifier}")
-    async def get_specific_blueprint_summary(blueprint_identifier: str) -> str:
-        """
-        Get summary information about a specific blueprint.
-        
-        Path parameters:
-            blueprint_identifier: The unique identifier of the blueprint
-            
-        Returns:
-            A formatted text representation of the blueprint in summary format, including:
-            - Title and identifier
-            - Description (if available)
-        """
-        try:
-            return await _get_blueprint(blueprint_identifier, detailed=False)
-        except Exception as e:
-            logger.error(f"Error in get_specific_blueprint_summary resource: {str(e)}", exc_info=True)
-            return f"❌ Error retrieving blueprint summary {blueprint_identifier}: {str(e)}"


### PR DESCRIPTION
This PR streamlines the blueprint resources by focusing on list-based endpoints while removing individual blueprint endpoints.

Key Changes:
- Removed individual blueprint endpoints (`port-blueprint://` and `port-blueprint-summary://`)
- Simplified resource patterns documentation to focus on the two main endpoints:
  - `port-blueprints:` - Summarized list (title, identifier, description)
  - `port-blueprints-detailed:` - Detailed list (includes schema properties and relations)
- Removed redundant code including the `_get_blueprint()` helper function
- Updated documentation to be more concise and clearer about the available endpoints

The specific blueprint resource isn't clearly available through an MCP resource so it keep the code lighter