### PR TITLE
 Feat: Add Port Scorecard Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
 # Port MCP Server
 
-A Model Context Protocol (MCP) server for the [Port.io API](https://www.getport.io/), enabling Claude to interact with Port.io's developer platform capabilities.
+A Model Context Protocol (MCP) server for the [Port.io API](https://www.getport.io/), enabling Claude to interact with Port.io's developer platform capabilities using natural language.
+
+## What You Can Do With Port MCP
+
+Transform how you work with Port.io using natural language:
+
+### Find Information Quickly
+- **Get entity details** - "Who is the owner of service X?"
+- **Check on-call status** - "Who is on call right now?"
+- **Get catalog insights** - "How many services do we have in production?"
+
+### Analyze Scorecards 
+- **Identify weak points** - "Which services are failing for the gold level and why?"
+- **Get compliance status** - "Show me all services that don't meet our security requirements"
+- **Improve quality** - "What do I need to fix to reach the next scorecard level?"
+
+### Create Resources
+- **Build scorecards** - "Create a new scorecard called 'Security Posture' with levels Basic, Silver, and Gold"
+- **Define rules** - "Add a rule that requires services to have a team owner to reach the Silver level"
+- **Setup quality gates** - "Create a rule that checks if services have proper documentation"
+
+We're continuously expanding Port MCP's capabilities. Have a suggestion? We'd love to hear your feedback on our [roadmap](https://roadmap.getport.io/ideas)!
 
 ## Installation
 
@@ -71,16 +92,7 @@ chmod +x /path/to/your/file/run-port-mcp.sh
 
 ![Cursor MCP Screenshot](/assets/cursor_mcp_screenshot.png)
 
-## Capabilities
-
-### Agent Tools
-
-1. `trigger_port_agent`
-   - Trigger the Port.io AI agent with a prompt and wait for completion
-   - Required inputs:
-     - `prompt` (string): The prompt to send to the Port.io AI agent
-   - Returns: Agent response with status, output, and any required actions
-   - Note: The agent may return action URLs for bug reports or other tasks that require user interaction
+## Available Tools
 
 ### Blueprint Tools
 
@@ -96,112 +108,36 @@ chmod +x /path/to/your/file/run-port-mcp.sh
      - `blueprint_identifier` (string): The unique identifier of the blueprint to retrieve
    - Optional inputs:
      - `detailed` (boolean, default: true): Return complete schema details
-   - Returns: Formatted text representation of the specified blueprint
 
-### Entity Tools
+### Scorecard Tools
 
-Will be added in the future.
+1. `get_scorecards`
+   - Retrieve all scorecards from Port
+   - Optional inputs:
+     - `detailed` (boolean, default: false): Return complete scorecard details
 
-## Development
+2. `get_scorecard`
+   - Retrieve information about a specific scorecard by its identifier
+   - Required inputs:
+     - `scorecard_id` (string): The unique identifier of the scorecard to retrieve
+     - `blueprint_id` (string, optional): The identifier of the blueprint the scorecard belongs to
 
-### Local Setup
+3. `create_scorecard`
+   - Create a new scorecard for a specific blueprint
+   - Required inputs:
+     - `blueprint_id` (string): The identifier of the blueprint to create the scorecard for
+     - `identifier` (string): The unique identifier for the new scorecard
+     - `title` (string): The display title of the scorecard
+     - `levels` (list): List of levels for the scorecard
+   - Optional inputs:
+     - `rules` (list): List of rules for the scorecard
+     - `description` (string): Description for the scorecard
 
-1. Create and activate a virtual environment:
-```bash
-# Create and activate virtual environment
-python -m venv .venv
-source .venv/bin/activate  # On Unix/macOS
-# or
-.venv\Scripts\activate  # On Windows
-```
+## Feedback and Roadmap
 
-2. Install dependencies:
-```bash
-# Install in development mode
-pip install -e .
+We're continuously improving Port MCP and would love to hear from you! Please share your feedback and feature requests on our [roadmap page](https://roadmap.getport.io/ideas).
 
-# Install development dependencies
-pip install -r requirements-dev.txt
-```
-
-3. Run the server locally:
-```bash
-python -m src.mcp_server_port --client-id "CLIENT_ID" --client-secret "CLIENT_SECRET" --region "REGION"
-```
-
-### Publishing a New Version
-
-There are two ways to publish a new version: manually following all steps, or using the automated Make commands.
-
-#### Manual Process
-
-1. Ensure you're on the main branch and it's up to date:
-```bash
-git checkout main
-git pull origin main
-```
-
-2. Merge the feature/release branch with changelog updates:
-```bash
-git merge feature/your-release-branch
-```
-
-3. Update version in `pyproject.toml`
-
-4. Commit version bump:
-```bash
-git add pyproject.toml
-git commit -m "chore: bump version to X.Y.Z"
-git push origin main
-```
-
-5. Create and push a new Git tag:
-```bash
-git tag -a vX.Y.Z -m "Release version X.Y.Z"
-git push origin vX.Y.Z
-```
-
-6. Build and publish to PyPI:
-```bash
-# Ensure you have the latest build tools
-pip install --upgrade build twine
-
-# Build the package
-python -m build
-
-# Check the package
-twine check dist/*
-
-# Upload to PyPI
-twine upload dist/mcp_server_port-X.Y.Z*
-```
-
-7. Create a GitHub release:
-   - Go to the repository's Releases page
-   - Click "Create new release"
-   - Select the tag you just pushed
-   - Title it "Release X.Y.Z"
-   - Include the changelog in the description
-   - Publish the release
-
-#### Automated Process
-
-You can use the provided Makefile commands to automate the release process:
-
-```bash
-# Update version and create release
-make release VERSION=X.Y.Z
-
-# Or run steps individually:
-make bump-version VERSION=X.Y.Z  # Updates pyproject.toml
-make tag VERSION=X.Y.Z          # Creates and pushes git tag
-make build                      # Builds the package
-make publish                    # Publishes to PyPI
-```
-
-Note: The automated process still requires you to manually create the GitHub release with changelog information.
-
-### Troubleshooting
+## Troubleshooting
 
 If you encounter authentication errors, verify that:
 1. Your Port credentials are correctly set in the arguments

--- a/src/mcp_server_port/client/__init__.py
+++ b/src/mcp_server_port/client/__init__.py
@@ -4,10 +4,12 @@ from .client import PortClient
 from .agent import PortAgentClient
 from .blueprints import PortBlueprintClient
 from .entities import PortEntityClient
+from .scorecards import PortScorecardClient
 
 __all__ = [
     'PortClient',
     'PortAgentClient', 
     'PortBlueprintClient', 
-    'PortEntityClient'
+    'PortEntityClient',
+    'PortScorecardClient'
 ] 

--- a/src/mcp_server_port/client/scorecards.py
+++ b/src/mcp_server_port/client/scorecards.py
@@ -1,0 +1,267 @@
+import logging
+from typing import Dict, List, Union, Any
+from ..models.models import PortScorecard, PortScorecardList
+from ..utils import PortError
+
+logger = logging.getLogger(__name__)
+
+class PortScorecardClient:
+    """Client for interacting with Port Scorecard APIs."""
+    
+    def __init__(self, client):
+        self._client = client
+
+    async def get_scorecards(self) -> Union[PortScorecardList, str]:
+        """
+        Get all scorecards.
+        
+        Returns:
+            PortScorecardList: A list of scorecards
+        """
+        if not self._client:
+            raise PortError("Cannot get scorecards: Port client not initialized with credentials")
+        
+        try:
+            logger.info("Getting all scorecards from Port")
+            
+            # Use the SDK's scorecard methods
+            scorecards_data = self._client.scorecards.get_scorecards()
+            scorecards = []
+            
+            for scorecard_data in scorecards_data:
+                scorecard = PortScorecard(
+                    identifier=scorecard_data.get("identifier", ""),
+                    title=scorecard_data.get("title", "Untitled Scorecard"),
+                    description=scorecard_data.get("description"),
+                    blueprint=scorecard_data.get("blueprint", ""),
+                    rules=scorecard_data.get("rules", []),
+                    levels=scorecard_data.get("levels", []),
+                    id=scorecard_data.get("id"),
+                    calculation_method=scorecard_data.get("calculationMethod"),
+                    created_at=scorecard_data.get("createdAt"),
+                    created_by=scorecard_data.get("createdBy"),
+                    updated_at=scorecard_data.get("updatedAt"),
+                    updated_by=scorecard_data.get("updatedBy")
+                )
+                scorecards.append(scorecard)
+            
+            scorecard_list = PortScorecardList(
+                scorecards=scorecards
+            )
+            return scorecard_list
+            
+        except Exception as e:
+            logger.error(f"Error in get_scorecards: {str(e)}")
+            # Check if this is an HTTP error and extract more details
+            if hasattr(e, 'response') and hasattr(e.response, 'status_code'):
+                status_code = e.response.status_code
+                try:
+                    # Try to extract the error message from the response JSON
+                    error_data = e.response.json()
+                    error_message = error_data.get('message', str(e))
+                    if 'details' in error_data:
+                        error_message += f". Details: {error_data['details']}"
+                    
+                    raise PortError(f"Error getting scorecards: {status_code} - {error_message}")
+                except (ValueError, AttributeError):
+                    # If we can't parse the JSON, just include the status code
+                    raise PortError(f"Error getting scorecards: {status_code} - {str(e)}")
+            else:
+                raise PortError(f"Error getting scorecards: {str(e)}")
+    
+    async def get_scorecard(self, scorecard_id: str, blueprint_id: str = None) -> Union[PortScorecard, str]:
+        """
+        Get a specific scorecard by identifier.
+        
+        Args:
+            scorecard_id: The identifier of the scorecard
+            blueprint_id: The identifier of the blueprint the scorecard belongs to
+                          If not provided, will try to find it from the list of scorecards
+            
+        Returns:
+            PortScorecard: The scorecard object
+        """
+        if not self._client:
+            raise PortError("Cannot get scorecard: Port client not initialized with credentials")
+        
+        try:
+            # If blueprint_id is not provided, we need to fetch all scorecards and find the matching one
+            if not blueprint_id:
+                logger.info(f"Blueprint ID not provided, finding scorecard '{scorecard_id}' from all scorecards")
+                scorecards = await self.get_scorecards()
+                
+                # Find the scorecard with matching identifier
+                for scorecard in scorecards.scorecards:
+                    if scorecard.identifier == scorecard_id:
+                        blueprint_id = scorecard.blueprint
+                        break
+                        
+                if not blueprint_id:
+                    raise PortError(f"Could not find blueprint for scorecard '{scorecard_id}'")
+            
+            logger.info(f"Getting scorecard '{scorecard_id}' from blueprint '{blueprint_id}'")
+            
+            # Use direct API call with the correct URL format
+            response = self._client.make_request("GET", f"blueprints/{blueprint_id}/scorecards/{scorecard_id}")
+            scorecard_data = response.json()
+            
+            # The API returns the scorecard object nested under a 'scorecard' key
+            if isinstance(scorecard_data, dict) and "scorecard" in scorecard_data:
+                scorecard_data = scorecard_data.get("scorecard", {})
+            
+            scorecard = PortScorecard(
+                identifier=scorecard_data.get("identifier", ""),
+                title=scorecard_data.get("title", "Untitled Scorecard"),
+                description=scorecard_data.get("description"),
+                blueprint=scorecard_data.get("blueprint", ""),
+                rules=scorecard_data.get("rules", []),
+                levels=scorecard_data.get("levels", []),
+                id=scorecard_data.get("id"),
+                calculation_method=scorecard_data.get("calculationMethod"),
+                created_at=scorecard_data.get("createdAt"),
+                created_by=scorecard_data.get("createdBy"),
+                updated_at=scorecard_data.get("updatedAt"),
+                updated_by=scorecard_data.get("updatedBy")
+            )
+            
+            return scorecard
+            
+        except Exception as e:
+            logger.error(f"Error in get_scorecard: {str(e)}")
+            # Check if this is an HTTP error and extract more details
+            if hasattr(e, 'response') and hasattr(e.response, 'status_code'):
+                status_code = e.response.status_code
+                try:
+                    # Try to extract the error message from the response JSON
+                    error_data = e.response.json()
+                    error_message = error_data.get('message', str(e))
+                    if 'details' in error_data:
+                        error_message += f". Details: {error_data['details']}"
+                    
+                    raise PortError(f"Error getting scorecard '{scorecard_id}': {status_code} - {error_message}")
+                except (ValueError, AttributeError):
+                    # If we can't parse the JSON, just include the status code
+                    raise PortError(f"Error getting scorecard '{scorecard_id}': {status_code} - {str(e)}")
+            else:
+                raise PortError(f"Error getting scorecard '{scorecard_id}': {str(e)}")
+    
+    async def create_scorecard(self, blueprint_id: str, scorecard_data: Dict[str, Any]) -> PortScorecard:
+        """
+        Create a new scorecard.
+        
+        Args:
+            blueprint_id: The identifier of the blueprint to create the scorecard for
+            scorecard_data: Data for the scorecard to create
+            
+        Returns:
+            PortScorecard: The created scorecard
+        """
+        if not self._client:
+            raise PortError("Cannot create scorecard: Port client not initialized with credentials")
+        
+        try:
+            logger.info(f"Creating scorecard in blueprint '{blueprint_id}'")
+            
+            # Use direct API call with the correct URL format
+            response = self._client.make_request("POST", f"blueprints/{blueprint_id}/scorecards", json=scorecard_data)
+            created_data = response.json()
+            
+            # The API might return different formats for create operations
+            if isinstance(created_data, dict) and "scorecard" in created_data:
+                created_data = created_data.get("scorecard", {})
+            
+            created_scorecard = PortScorecard(
+                identifier=created_data.get("identifier", ""),
+                title=created_data.get("title", "Untitled Scorecard"),
+                description=created_data.get("description"),
+                blueprint=created_data.get("blueprint", blueprint_id),
+                rules=created_data.get("rules", []),
+                levels=created_data.get("levels", []),
+                id=created_data.get("id"),
+                calculation_method=created_data.get("calculationMethod"),
+                created_at=created_data.get("createdAt"),
+                created_by=created_data.get("createdBy"),
+                updated_at=created_data.get("updatedAt"),
+                updated_by=created_data.get("updatedBy")
+            )
+            
+            return created_scorecard
+            
+        except Exception as e:
+            logger.error(f"Error in create_scorecard: {str(e)}")
+            # Check if this is an HTTP error and extract more details
+            if hasattr(e, 'response') and hasattr(e.response, 'status_code'):
+                status_code = e.response.status_code
+                try:
+                    # Try to extract the error message from the response JSON
+                    error_data = e.response.json()
+                    error_message = error_data.get('message', str(e))
+                    if 'details' in error_data:
+                        error_message += f". Details: {error_data['details']}"
+                    
+                    raise PortError(f"Error creating scorecard: {status_code} - {error_message}")
+                except (ValueError, AttributeError):
+                    # If we can't parse the JSON, just include the status code
+                    raise PortError(f"Error creating scorecard: {status_code} - {str(e)}")
+            else:
+                raise PortError(f"Error creating scorecard: {str(e)}")
+    
+    async def delete_scorecard(self, scorecard_id: str, blueprint_id: str) -> bool:
+        """
+        Delete a scorecard by ID.
+        
+        Args:
+            scorecard_id: The identifier of the scorecard to delete
+            blueprint_id: The identifier of the blueprint the scorecard belongs to
+            
+        Returns:
+            bool: True if deletion was successful
+        """
+        if not self._client:
+            raise PortError("Cannot delete scorecard: Port client not initialized with credentials")
+        
+        try:
+            logger.info(f"Deleting scorecard '{scorecard_id}' from blueprint '{blueprint_id}'")
+            
+            # Use direct API call with the correct URL format
+            response = self._client.make_request("DELETE", f"blueprints/{blueprint_id}/scorecards/{scorecard_id}")
+            
+            # Check if the request was successful (204 No Content is common for DELETE operations)
+            if response.status_code in (200, 202, 204):
+                return True
+            else:
+                # Try to get the error message from the response, but handle the case where 
+                # the response might not have a JSON body
+                error_message = "Unknown error"
+                try:
+                    if hasattr(response, 'json') and callable(response.json):
+                        response_json = response.json()
+                        if isinstance(response_json, dict):
+                            error_message = response_json.get('message', 'Unknown error')
+                            # Add details if available
+                            if 'details' in response_json:
+                                error_message += f". Details: {response_json['details']}"
+                except Exception:
+                    # If we can't parse the json, just use the status code
+                    error_message = f"HTTP {response.status_code}"
+                    
+                raise PortError(f"Error deleting scorecard: {response.status_code} - {error_message}")
+            
+        except Exception as e:
+            logger.error(f"Error in delete_scorecard: {str(e)}")
+            # Check if this is an HTTP error and extract more details
+            if hasattr(e, 'response') and hasattr(e.response, 'status_code'):
+                status_code = e.response.status_code
+                try:
+                    # Try to extract the error message from the response JSON
+                    error_data = e.response.json()
+                    error_message = error_data.get('message', str(e))
+                    if 'details' in error_data:
+                        error_message += f". Details: {error_data['details']}"
+                    
+                    raise PortError(f"Error deleting scorecard '{scorecard_id}': {status_code} - {error_message}")
+                except (ValueError, AttributeError):
+                    # If we can't parse the JSON, just include the status code
+                    raise PortError(f"Error deleting scorecard '{scorecard_id}': {status_code} - {str(e)}")
+            else:
+                raise PortError(f"Error deleting scorecard '{scorecard_id}': {str(e)}") 

--- a/src/mcp_server_port/models/models.py
+++ b/src/mcp_server_port/models/models.py
@@ -174,6 +174,109 @@ class PortEntityList:
         return result
 
 @dataclass
+class PortScorecard:
+    """Data model for Port scorecard."""
+    identifier: str
+    title: str
+    blueprint: str
+    rules: List[Dict[str, Any]] = field(default_factory=list)
+    description: Optional[str] = None
+    calculation_method: Optional[str] = None
+    levels: List[Dict[str, Any]] = field(default_factory=list)
+    id: Optional[str] = None
+    created_at: Optional[str] = None
+    created_by: Optional[str] = None
+    updated_at: Optional[str] = None
+    updated_by: Optional[str] = None
+    
+    def to_summary(self) -> str:
+        """Returns a summary of the scorecard (title, identifier, blueprint)."""
+        desc = f"\nDescription: {self.description}" if self.description else ""
+        return f"{self.title} (ID: {self.identifier})\nBlueprint: {self.blueprint}{desc}"
+    
+    def to_text(self, detailed: bool = True) -> str:
+        """
+        Returns a textual representation of the scorecard.
+        
+        Args:
+            detailed: If True, includes rules and calculation method.
+                     If False, returns summary.
+        """
+        if not detailed:
+            return self.to_summary()
+            
+        result = f"# {self.to_summary()}\n"
+        
+        if self.calculation_method:
+            result += f"\nCalculation Method: {self.calculation_method}\n"
+        
+        if self.levels:
+            result += "\n## Levels\n"
+            for level in self.levels:
+                level_title = level.get("title", "No Title")
+                level_color = level.get("color", "No Color")
+                result += f"- {level_title} (Color: {level_color})\n"
+        
+        if self.rules:
+            result += "\n## Rules\n"
+            for i, rule in enumerate(self.rules, 1):
+                rule_title = rule.get("title", f"Rule {i}")
+                rule_id = rule.get("identifier", "No ID")
+                rule_description = rule.get("description", "No description")
+                rule_level = rule.get("level", "No Level")
+                
+                result += f"### {rule_title} (ID: {rule_id})\n"
+                result += f"Description: {rule_description}\n"
+                result += f"Level: {rule_level}\n"
+                
+                # Add rule details if present
+                if "weight" in rule:
+                    result += f"Weight: {rule.get('weight')}\n"
+                if "query" in rule:
+                    query = rule.get("query", {})
+                    result += f"Query Type: {query.get('combinator', 'Not specified')}\n"
+                    
+                    # Include a simplified version of the query conditions
+                    if "conditions" in query:
+                        result += "Conditions:\n"
+                        for condition in query.get("conditions", []):
+                            property_name = condition.get("property", "unknown")
+                            operator = condition.get("operator", "unknown")
+                            value = condition.get("value", "") if "value" in condition else ""
+                            
+                            value_str = f" {value}" if value != "" else ""
+                            result += f"  - {property_name} {operator}{value_str}\n"
+                result += "\n"
+        
+        if self.created_at:
+            result += f"\nCreated: {self.created_at}\n"
+        if self.updated_at:
+            result += f"Updated: {self.updated_at}\n"
+        
+        return result
+
+@dataclass
+class PortScorecardList:
+    """Data model for a list of Port scorecards."""
+    scorecards: List[PortScorecard] = field(default_factory=list)
+    
+    def to_text(self, detailed: bool = False) -> str:
+        """
+        Returns a textual representation of the scorecard list.
+        
+        Args:
+            detailed: If True, includes detailed information for each scorecard.
+        """
+        if not self.scorecards:
+            return "No scorecards found."
+        
+        result = "# Port Scorecards\n\n"
+        for i, scorecard in enumerate(self.scorecards, 1):
+            result += f"## {i}. {scorecard.to_text(detailed=detailed)}\n\n"
+        
+        return result
+
+@dataclass
 class PortAgentResponse:
     """Data model for Port AI agent response."""
     identifier: str

--- a/src/mcp_server_port/prompts/default_prompt.py
+++ b/src/mcp_server_port/prompts/default_prompt.py
@@ -17,6 +17,7 @@ def register(mcp: FastMCP) -> None:
 Key capabilities:
 - Blueprint and entity discovery
 - Entity details and relationships
+- Scorecard management for measuring quality and compliance
 - AI agent interactions for complex operations
 - Detailed schema introspection of Port resources
 
@@ -47,6 +48,35 @@ Tools:
   - Returns DETAILED format by default
   - Example: "Show me details of entity 'backend-api' in blueprint 'service'"
 
+- get_scorecards:
+  - Lists all scorecards available in your Port installation
+  - By default, returns scorecards in SUMMARY format (title, identifier, blueprint)
+  - For full details of all scorecards, including rules and levels, use detailed=True
+  - Example: "Show me all scorecards" or "List detailed scorecards with rules"
+
+- get_scorecard:
+  - Gets detailed information about a specific scorecard
+  - Requires the scorecard identifier
+  - Optionally accepts a blueprint_id parameter if you already know which blueprint the scorecard belongs to
+  - Returns DETAILED format by default (with rules, levels, and metadata)
+  - For summary only, use detailed=False
+  - Example: "Show me details of the 'ProductionReadiness' scorecard" or "Get the 'Security' scorecard from the 'service' blueprint"
+
+- create_scorecard:
+  - Creates a new scorecard for a specific blueprint
+  - Required parameters: blueprint_id, identifier, title, levels (list of level objects)
+  - Optional parameters: rules (list of rule objects), description
+  - IMPORTANT: The first level in the levels list is considered the base level and cannot have rules associated with it
+  - Each level should have 'title' and 'color' properties
+  - Each rule must reference a level from the levels list (except the base/first level)
+  - Example: "Create a security compliance scorecard for the 'service' blueprint with Bronze, Silver, and Gold levels"
+
+- delete_scorecard:
+  - Deletes an existing scorecard
+  - Required parameters: scorecard_id, blueprint_id
+  - Use with caution as this operation is irreversible
+  - Example: "Delete the 'TestScorecard' scorecard from the 'service' blueprint"
+
 - invoke_ai_agent:
   - Interact with user-defined AI agents for complex queries or actions
   - Use for natural language interactions with Port data
@@ -57,6 +87,17 @@ Recommended workflow for finding entity information:
 1. Use get_blueprints (summary) to find the relevant blueprint identifier
 2. Use get_entities (summary) with that blueprint ID to list available entities
 3. Once you find the entity you're interested in, use get_entity (detailed) to see all its details
+
+Recommended workflow for scorecard information:
+1. Use get_scorecards (summary) to see all available scorecards
+2. Use get_scorecard with the specific scorecard identifier to see its rules and levels
+
+Recommended workflow for creating scorecards:
+1. Use get_blueprint (detailed) to understand the properties available in a blueprint
+2. Define appropriate levels (Basic, Bronze, Silver, Gold is a common pattern)
+3. Create rules based on blueprint properties, ensuring the first level (Basic) doesn't have any rules
+4. Use create_scorecard with the blueprint_id, defined levels and rules
+5. Verify the scorecard was created using get_scorecard
 
 Resource patterns:
 - port-blueprints: - Summarized list of all blueprints

--- a/src/mcp_server_port/server.py
+++ b/src/mcp_server_port/server.py
@@ -6,9 +6,10 @@ import os
 from mcp.server.fastmcp import FastMCP
 from .client import PortClient
 from .utils import setup_logging
-from .tools.agent_tools import register as register_agent_tools
+# from .tools.agent_tools import register as register_agent_tools
 from .tools.blueprint_tools import register as register_blueprint_tools
 from .tools.entity_tools import register as register_entity_tools
+from .tools.scorecard_tools import register as register_scorecard_tools
 from .resources import register_all as register_all_resources
 from .prompts import register_all as register_all_prompts
 
@@ -46,9 +47,10 @@ def main(client_id=None, client_secret=None, region="EU", **kwargs):
         mcp = FastMCP("Port")
         
         # Register tools
-        register_agent_tools(mcp, port_client)
+        # register_agent_tools(mcp, port_client)
         register_blueprint_tools(mcp, port_client)
         register_entity_tools(mcp, port_client)
+        register_scorecard_tools(mcp, port_client)
         
         # Register resources
         register_all_resources(mcp, port_client)

--- a/src/mcp_server_port/tools/scorecard_tools.py
+++ b/src/mcp_server_port/tools/scorecard_tools.py
@@ -1,0 +1,187 @@
+"""Scorecard-related tools for Port MCP server."""
+
+import logging
+import json
+from typing import Any, Dict, List, Optional, Union
+
+from mcp.server.fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+def register(mcp: FastMCP, port_client: Any) -> None:
+    """
+    Register scorecard tools with the FastMCP server.
+    
+    Args:
+        mcp: The FastMCP server instance
+        port_client: The Port client instance
+        
+    Scorecard model provides these methods:
+        - to_summary(): Returns just the basic information like title, identifier, blueprint
+        - to_text(detailed=False): Returns summary view (same as to_summary())
+        - to_text(detailed=True): Returns detailed view (with rules, calculation method, and timestamps)
+    """
+    
+    @mcp.tool()
+    async def get_scorecards(detailed: bool = False) -> str:
+        """
+        Retrieve all scorecards from Port.
+        
+        Args:
+            detailed: If True, returns complete scorecard details including rules and calculation method.
+                     If False (default), returns summary information only.
+        
+        Returns:
+            A formatted text representation of all scorecards.
+            Summary format includes title, identifier and blueprint.
+            Detailed format includes rules, calculation method, and timestamps.
+        """
+        try:
+            logger.info(f"Retrieving all scorecards from Port (detailed={detailed})")
+            scorecards = await port_client.get_all_scorecards()
+            return scorecards.to_text(detailed=detailed) if hasattr(scorecards, 'to_text') else str(scorecards)
+        except Exception as e:
+            logger.error(f"Error in get_scorecards: {str(e)}", exc_info=True)
+            # Pass along the full error message without truncating it
+            error_message = str(e)
+            return f"❌ Error retrieving scorecards: {error_message}"
+            
+    @mcp.tool()
+    async def get_scorecard(scorecard_id: str, blueprint_id: str = None, detailed: bool = True) -> str:
+        """
+        Retrieve information about a specific scorecard by its identifier.
+        
+        Args:
+            scorecard_id: The unique identifier of the scorecard to retrieve
+            blueprint_id: The identifier of the blueprint the scorecard belongs to.
+                        If not provided, will try to find it from the list of scorecards.
+            detailed: If True (default), returns complete scorecard details.
+                     If False, returns summary information only.
+            
+        Returns:
+            A formatted text representation of the scorecard.
+            Summary format includes title, identifier and blueprint.
+            Detailed format includes rules, calculation method, and timestamps.
+        """
+        try:
+            logger.info(f"Retrieving scorecard '{scorecard_id}' (detailed={detailed})")
+            
+            if blueprint_id:
+                logger.info(f"Blueprint ID provided: {blueprint_id}")
+                
+            scorecard = await port_client.get_scorecard_details(scorecard_id, blueprint_id)
+            return scorecard.to_text(detailed=detailed) if hasattr(scorecard, 'to_text') else str(scorecard)
+        except Exception as e:
+            logger.error(f"Error in get_scorecard: {str(e)}", exc_info=True)
+            # Pass along the full error message without truncating it
+            error_message = str(e)
+            return f"❌ Error retrieving scorecard '{scorecard_id}': {error_message}"
+    
+    @mcp.tool()
+    async def create_scorecard(
+        blueprint_id: str,
+        identifier: str,
+        title: str,
+        levels: List[Dict[str, str]],
+        rules: List[Dict[str, Any]] = None,
+        description: str = None
+    ) -> str:
+        """
+        Create a new scorecard for a specific blueprint.
+        
+        Args:
+            blueprint_id: The identifier of the blueprint to create the scorecard for
+            identifier: The unique identifier for the new scorecard
+            title: The display title of the scorecard
+            levels: List of levels for the scorecard, each with "title" and "color" properties
+                   The first level is the base level and should not have rules associated with it
+                   Example: [{"title": "Basic", "color": "blue"}, {"title": "Silver", "color": "silver"}]
+            rules: Optional list of rules for the scorecard
+                  Each rule should have at minimum: identifier, title, level, and query properties
+                  The level must match one of the levels defined in the levels parameter (except the first level)
+                  Example rule: {
+                    "identifier": "has-team",
+                    "title": "Has responsible team",
+                    "level": "Silver",
+                    "query": {
+                      "combinator": "and",
+                      "conditions": [{"property": "$team", "operator": "isNotEmpty"}]
+                    }
+                  }
+            description: Optional description for the scorecard
+            
+        Returns:
+            A formatted text representation of the created scorecard if successful
+            An error message if creation failed
+        """
+        try:
+            # Validate that rules don't reference the first level (base level)
+            if rules:
+                base_level = levels[0]["title"] if levels else None
+                for rule in rules:
+                    if rule.get("level") == base_level:
+                        return f"❌ Error creating scorecard: The base level '{base_level}' cannot have rules associated with it."
+            
+            # Prepare the scorecard data
+            scorecard_data = {
+                "identifier": identifier,
+                "title": title,
+                "levels": levels,
+                "rules": rules or []
+            }
+            
+            if description:
+                scorecard_data["description"] = description
+            
+            logger.info(f"Creating scorecard '{identifier}' for blueprint '{blueprint_id}'")
+            logger.debug(f"Scorecard data: {json.dumps(scorecard_data, indent=2)}")
+            
+            # Create the scorecard
+            created_scorecard = await port_client.create_new_scorecard(blueprint_id, scorecard_data)
+            
+            # Return the created scorecard details
+            return (
+                f"✅ Successfully created scorecard '{title}' (ID: {identifier})\n\n"
+                f"{created_scorecard.to_text(detailed=True) if hasattr(created_scorecard, 'to_text') else str(created_scorecard)}"
+            )
+        except Exception as e:
+            logger.error(f"Error in create_scorecard: {str(e)}", exc_info=True)
+            # Pass along the full error message without truncating it
+            error_message = str(e)
+            return f"❌ Error creating scorecard '{identifier}' for blueprint '{blueprint_id}': {error_message}"
+    
+    @mcp.tool()
+    async def delete_scorecard(scorecard_id: str, blueprint_id: str) -> str:
+        """
+        Delete a scorecard from Port.
+        
+        Args:
+            scorecard_id: The unique identifier of the scorecard to delete
+            blueprint_id: The identifier of the blueprint the scorecard belongs to
+            
+        Returns:
+            A success message if deletion was successful
+            An error message if deletion failed
+        """
+        try:
+            logger.info(f"Deleting scorecard '{scorecard_id}' from blueprint '{blueprint_id}'")
+            
+            # First verify that the scorecard exists
+            try:
+                await port_client.get_scorecard_details(scorecard_id, blueprint_id)
+            except Exception as e:
+                logger.warning(f"Scorecard '{scorecard_id}' not found or not accessible: {str(e)}")
+                return f"❌ Cannot delete scorecard '{scorecard_id}': Scorecard not found or not accessible"
+            
+            # Delete the scorecard
+            result = await port_client.delete_scorecard(scorecard_id, blueprint_id)
+            
+            if result:
+                return f"✅ Successfully deleted scorecard '{scorecard_id}' from blueprint '{blueprint_id}'"
+            else:
+                return f"❌ Failed to delete scorecard '{scorecard_id}'. No error was reported, but the operation may not have succeeded."
+        except Exception as e:
+            logger.error(f"Error in delete_scorecard: {str(e)}", exc_info=True)
+            # Pass along the full error message without truncating it
+            error_message = str(e)
+            return f"❌ Error deleting scorecard '{scorecard_id}': {error_message}" 

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -2,4 +2,5 @@ from mcp_server_port.client import PortClient
 
 # Import fixtures from fixtures directory
 from .fixtures.blueprints import MOCK_BLUEPRINTS_DATA
+from .fixtures.scorecards import MOCK_SCORECARDS_DATA, MOCK_SCORECARD_DICT
 from .fixtures.client_fixtures import mock_client

--- a/tests/client/fixtures/client_fixtures.py
+++ b/tests/client/fixtures/client_fixtures.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from mcp_server_port.client import PortClient
 from .blueprints import MOCK_BLUEPRINTS_DATA
 from .entities import MOCK_ENTITIES_DATA
+from .scorecards import MOCK_SCORECARDS_DATA, MOCK_SCORECARD_DICT
 
 @pytest.fixture
 def mock_client():
@@ -17,6 +18,7 @@ def mock_client():
         # Set up the blueprints property on the SDK client mock
         sdk_client_mock.blueprints = MagicMock()
         sdk_client_mock.entities = MagicMock()
+        sdk_client_mock.scorecards = MagicMock()
         
         # Set up the blueprints methods
         sdk_client_mock.blueprints.get_blueprints = MagicMock(return_value=MOCK_BLUEPRINTS_DATA)
@@ -44,6 +46,66 @@ def mock_client():
             
         sdk_client_mock.entities.get_entities = MagicMock(side_effect=mock_get_entities)
         sdk_client_mock.entities.get_entity = MagicMock(side_effect=mock_get_entity)
+        
+        # Set up the scorecard methods
+        def mock_get_scorecards():
+            return MOCK_SCORECARDS_DATA
+            
+        def mock_get_scorecard(scorecard_id):
+            if scorecard_id in MOCK_SCORECARD_DICT:
+                # In a real API, this would probably be wrapped in a 'scorecard' key
+                return {"scorecard": MOCK_SCORECARD_DICT[scorecard_id]}
+            raise Exception(f"Scorecard with ID {scorecard_id} not found")
+            
+        def mock_create_scorecard(blueprint_id, scorecard_data):
+            return {"scorecard": scorecard_data}
+            
+        # Add scorecard methods
+        sdk_client_mock.scorecards.get_scorecards = MagicMock(side_effect=mock_get_scorecards)
+        sdk_client_mock.scorecards.get_scorecard = MagicMock(side_effect=mock_get_scorecard)
+        sdk_client_mock.scorecards.create_scorecard = MagicMock(side_effect=mock_create_scorecard)
+        
+        # Mock the make_request method for direct API calls
+        def mock_make_request(method, path, **kwargs):
+            mock_response = MagicMock()
+            mock_response.status_code = 200  # Default to 200 OK
+            
+            if path == "scorecards":
+                # Mock response for GET /scorecards
+                mock_response.json.return_value = {"ok": True, "scorecards": MOCK_SCORECARDS_DATA}
+            elif path.startswith("blueprints/") and "/scorecards/" in path:
+                # Mock response for GET /blueprints/{blueprint_id}/scorecards/{scorecard_id}
+                parts = path.split("/")
+                if len(parts) >= 4:
+                    blueprint_id = parts[1]
+                    scorecard_id = parts[3]
+                    
+                    # Find the matching scorecard
+                    for scorecard in MOCK_SCORECARDS_DATA:
+                        if scorecard["identifier"] == scorecard_id and scorecard["blueprint"] == blueprint_id:
+                            if method == "GET":
+                                mock_response.json.return_value = {"ok": True, "scorecard": scorecard}
+                            elif method == "DELETE":
+                                # For DELETE, just return a successful status code
+                                mock_response.status_code = 204
+                                # Ensure json doesn't return anything for 204 No Content response
+                                mock_response.json.side_effect = Exception("No content in DELETE response")
+                            break
+                    else:
+                        if method == "GET":
+                            mock_response.status_code = 404
+                            mock_response.json.return_value = {"ok": False, "error": f"Scorecard {scorecard_id} not found in blueprint {blueprint_id}"}
+                        elif method == "DELETE":
+                            mock_response.status_code = 404
+                            mock_response.json.return_value = {"ok": False, "error": f"Cannot delete: Scorecard {scorecard_id} not found in blueprint {blueprint_id}"}
+            elif path.startswith("blueprints/") and path.endswith("/scorecards") and method == "POST":
+                # Mock response for POST /blueprints/{blueprint_id}/scorecards
+                mock_response.status_code = 201
+                mock_response.json.return_value = {"ok": True, "scorecard": kwargs.get("json", {})}
+            
+            return mock_response
+            
+        sdk_client_mock.make_request = MagicMock(side_effect=mock_make_request)
         
         # Mock returns the SDK client mock
         mock_port_client.return_value = sdk_client_mock

--- a/tests/client/fixtures/scorecards.py
+++ b/tests/client/fixtures/scorecards.py
@@ -1,0 +1,189 @@
+"""Mock data for scorecard tests."""
+
+# Sample scorecard data based on API response
+MOCK_SCORECARDS_DATA = [
+    {
+        "id": "sc_3cAtWg4HHCJkd8Dl",
+        "identifier": "ProductionReadiness",
+        "title": "Production Readiness",
+        "levels": [
+            {
+                "color": "paleBlue",
+                "title": "Basic"
+            },
+            {
+                "color": "bronze",
+                "title": "Bronze"
+            },
+            {
+                "color": "silver",
+                "title": "Silver"
+            },
+            {
+                "color": "gold",
+                "title": "Gold"
+            }
+        ],
+        "blueprint": "service",
+        "rules": [
+            {
+                "identifier": "hasReadme",
+                "description": "Checks if the service has a readme file in the repository",
+                "title": "Has a readme",
+                "level": "Bronze",
+                "query": {
+                    "combinator": "and",
+                    "conditions": [
+                        {
+                            "operator": "isNotEmpty",
+                            "property": "readme"
+                        }
+                    ]
+                }
+            },
+            {
+                "identifier": "usesSupportedLang",
+                "description": "Checks if the service uses one of the supported languages. ",
+                "title": "Uses a supported language",
+                "level": "Silver",
+                "query": {
+                    "combinator": "or",
+                    "conditions": [
+                        {
+                            "operator": "=",
+                            "property": "language",
+                            "value": "Python"
+                        },
+                        {
+                            "operator": "=",
+                            "property": "language",
+                            "value": "JavaScript"
+                        },
+                        {
+                            "operator": "=",
+                            "property": "language",
+                            "value": "React"
+                        },
+                        {
+                            "operator": "=",
+                            "property": "language",
+                            "value": "TypeScript"
+                        }
+                    ]
+                }
+            }
+        ],
+        "createdAt": "2024-06-05T19:38:17.772Z",
+        "createdBy": "google-oauth2|116901613151982285771",
+        "updatedAt": "2024-07-30T06:58:57.834Z",
+        "updatedBy": "google-oauth2|116901613151982285771"
+    },
+    {
+        "id": "sc_Hs7CpLG0Y3qj1CIx",
+        "identifier": "configuration",
+        "title": "Configuration Checks",
+        "levels": [
+            {
+                "color": "paleBlue",
+                "title": "Basic"
+            },
+            {
+                "color": "bronze",
+                "title": "Bronze"
+            },
+            {
+                "color": "silver",
+                "title": "Silver"
+            },
+            {
+                "color": "gold",
+                "title": "Gold"
+            }
+        ],
+        "blueprint": "workload",
+        "rules": [
+            {
+                "identifier": "notPrivileged",
+                "level": "Bronze",
+                "query": {
+                    "combinator": "and",
+                    "conditions": [
+                        {
+                            "operator": "!=",
+                            "property": "hasPrivileged",
+                            "value": True
+                        }
+                    ]
+                },
+                "title": "No privilged containers"
+            },
+            {
+                "identifier": "hasLimits",
+                "level": "Bronze",
+                "query": {
+                    "combinator": "and",
+                    "conditions": [
+                        {
+                            "operator": "=",
+                            "property": "hasLimits",
+                            "value": True
+                        }
+                    ]
+                },
+                "title": "All containers have CPU and Memory limits"
+            }
+        ],
+        "createdAt": "2024-08-01T06:31:35.062Z",
+        "createdBy": "GiypjgSxnmNbFSldqkJuYrGHh1XHSREx",
+        "updatedAt": "2024-08-01T06:31:35.062Z",
+        "updatedBy": "GiypjgSxnmNbFSldqkJuYrGHh1XHSREx"
+    },
+    {
+        "id": "sc_egymGQWQ0pBAcR06",
+        "identifier": "DORA",
+        "title": "DORA Metrics",
+        "levels": [
+            {
+                "color": "paleBlue",
+                "title": "Basic"
+            },
+            {
+                "color": "bronze",
+                "title": "Bronze"
+            },
+            {
+                "color": "silver",
+                "title": "Silver"
+            },
+            {
+                "color": "gold",
+                "title": "Gold"
+            }
+        ],
+        "blueprint": "domain",
+        "rules": [
+            {
+                "identifier": "DeploymentFrequency",
+                "title": "Deployment Frequency > 3",
+                "level": "Bronze",
+                "query": {
+                    "combinator": "and",
+                    "conditions": [
+                        {
+                            "operator": ">",
+                            "property": "deployment_frequency",
+                            "value": 3
+                        }
+                    ]
+                }
+            }
+        ],
+        "createdAt": "2024-09-18T08:51:49.625Z",
+        "createdBy": "google-oauth2|116901613151982285771",
+        "updatedAt": "2024-09-18T08:51:49.625Z",
+        "updatedBy": "google-oauth2|116901613151982285771"
+    }
+]
+
+# Dictionary mapping scorecard identifiers to their data
+MOCK_SCORECARD_DICT = {scorecard["identifier"]: scorecard for scorecard in MOCK_SCORECARDS_DATA} 

--- a/tests/client/test_scorecards.py
+++ b/tests/client/test_scorecards.py
@@ -1,0 +1,388 @@
+import os
+import pytest
+import sys
+from dotenv import load_dotenv
+import json
+from unittest.mock import MagicMock, AsyncMock
+
+# Add the src directory to the path so we can import our modules
+sys.path.append('src')
+
+from mcp_server_port.client import PortClient
+from mcp_server_port.models.models import PortScorecardList, PortScorecard
+from mcp_server_port.utils import PortError
+
+# Load environment variables from .env file
+load_dotenv()
+
+# Get credentials from environment variables
+PORT_CLIENT_ID = os.getenv("PORT_CLIENT_ID")
+PORT_CLIENT_SECRET = os.getenv("PORT_CLIENT_SECRET")
+REGION = os.getenv("REGION", "EU")
+
+# Skip tests if credentials are not available
+require_credentials = pytest.mark.skipif(
+    not PORT_CLIENT_ID or not PORT_CLIENT_SECRET,
+    reason="Port credentials not available in environment variables"
+)
+
+@require_credentials
+class TestPortScorecardClient:
+    """Tests for the Port Scorecard Client functionality."""
+
+    @pytest.fixture
+    def client(self):
+        """Create a PortClient instance with credentials."""
+        return PortClient(
+            client_id=PORT_CLIENT_ID,
+            client_secret=PORT_CLIENT_SECRET,
+            region=REGION
+        )
+
+    @pytest.fixture
+    def mock_port_client(self):
+        """Create a mock PortClient instance for testing error scenarios."""
+        # Create a properly mocked client that won't make real API calls
+        port_client = MagicMock()
+        
+        # Setup the structure needed for the client
+        port_client._client = MagicMock()
+        
+        # Use AsyncMock for coroutine methods
+        port_client.create_new_scorecard = AsyncMock()
+        port_client.get_scorecard_details = AsyncMock()
+        port_client.scorecards = MagicMock()
+        
+        return port_client
+
+    @pytest.mark.asyncio
+    async def test_get_scorecards(self, client):
+        """Test getting all scorecards."""
+        # Get all scorecards
+        scorecard_list = await client.get_all_scorecards()
+        
+        # Validate the response type
+        assert isinstance(scorecard_list, PortScorecardList)
+        
+        # Print information about the scorecards
+        print(f"Found {len(scorecard_list.scorecards)} scorecards")
+        
+        # Skip further tests if no scorecards are found
+        if not scorecard_list.scorecards:
+            pytest.skip("No scorecards found to test with")
+            
+        # Validate that we have at least one scorecard
+        assert len(scorecard_list.scorecards) > 0
+        
+        # Validate the first scorecard
+        first_scorecard = scorecard_list.scorecards[0]
+        assert isinstance(first_scorecard, PortScorecard)
+        assert first_scorecard.identifier
+        assert first_scorecard.title
+        assert first_scorecard.blueprint
+        
+        # Print the first scorecard for debugging
+        print(f"First scorecard: {first_scorecard.title} (ID: {first_scorecard.identifier})")
+        print(f"Blueprint: {first_scorecard.blueprint}")
+        print(f"Rules count: {len(first_scorecard.rules)}")
+        print(f"Levels count: {len(first_scorecard.levels)}")
+
+    @pytest.mark.asyncio
+    async def test_get_scorecard(self, client):
+        """Test getting a specific scorecard by identifier."""
+        # First, get all scorecards to find one to test with
+        scorecard_list = await client.get_all_scorecards()
+        
+        # Validate the response type
+        assert isinstance(scorecard_list, PortScorecardList)
+        
+        # Print information about the scorecards
+        print(f"Found {len(scorecard_list.scorecards)} scorecards")
+        
+        # Skip if no scorecards are found
+        if not scorecard_list.scorecards:
+            pytest.skip("No scorecards found to test with")
+            
+        # Select the first scorecard
+        first_scorecard = scorecard_list.scorecards[0]
+        
+        # Print debug information about the scorecard
+        print(f"First scorecard debug info:")
+        print(f"  Title: {first_scorecard.title}")
+        print(f"  Identifier: {first_scorecard.identifier}")
+        print(f"  Blueprint: {first_scorecard.blueprint}")
+        
+        scorecard_identifier = first_scorecard.identifier
+        blueprint_id = first_scorecard.blueprint
+        
+        if not scorecard_identifier or not blueprint_id:
+            pytest.skip("Scorecard identifier or blueprint is missing, cannot test get_scorecard")
+        
+        print(f"Testing get_scorecard with identifier: '{scorecard_identifier}' and blueprint: '{blueprint_id}'")
+        
+        try:
+            # Get the specific scorecard by identifier and blueprint
+            scorecard = await client.get_scorecard_details(scorecard_identifier, blueprint_id)
+            
+            # Validate the response
+            assert isinstance(scorecard, PortScorecard)
+            assert scorecard.identifier == scorecard_identifier
+            assert scorecard.blueprint == blueprint_id
+            assert scorecard.title
+            
+            # Print the scorecard details for debugging
+            print(f"Successfully retrieved scorecard: {scorecard.title}")
+            print(f"Blueprint: {scorecard.blueprint}")
+            print(f"Rules count: {len(scorecard.rules)}")
+            print(f"Levels count: {len(scorecard.levels)}")
+            
+            # Validate rules if present
+            if scorecard.rules:
+                first_rule = scorecard.rules[0]
+                assert "identifier" in first_rule
+                assert "title" in first_rule
+                
+            # Validate levels if present
+            if scorecard.levels:
+                first_level = scorecard.levels[0]
+                assert "title" in first_level
+                
+            print("Scorecard test successful!")
+        except Exception as e:
+            print(f"Error retrieving scorecard: {str(e)}")
+            import traceback
+            traceback.print_exc()
+            pytest.fail(f"Could not retrieve scorecard: {str(e)}")
+
+    @pytest.mark.asyncio
+    async def test_create_and_delete_scorecard(self, client):
+        """Test creating a new scorecard and then deleting it."""
+        # First, get all blueprints to find one to use
+        try:
+            # Get all blueprints
+            print("Fetching blueprints...")
+            blueprints = await client.get_blueprints()
+            
+            if not blueprints or not blueprints.blueprints:
+                pytest.skip("No blueprints found to test with")
+                
+            # Choose a blueprint with properties
+            test_blueprint = None
+            for blueprint in blueprints.blueprints:
+                if blueprint.schema and "properties" in blueprint.schema and blueprint.schema["properties"]:
+                    test_blueprint = blueprint
+                    break
+                    
+            if not test_blueprint:
+                pytest.skip("No blueprint with properties found to test with")
+                
+            blueprint_id = test_blueprint.identifier
+            
+            # Print detailed blueprint information for debugging
+            print(f"\n===== BLUEPRINT DETAILS =====")
+            print(f"Blueprint ID: {blueprint_id}")
+            print(f"Blueprint Title: {test_blueprint.title}")
+            print("Blueprint Properties:")
+            for prop_name, prop_details in test_blueprint.schema["properties"].items():
+                prop_type = prop_details.get("type", "unknown")
+                print(f"  - {prop_name} (Type: {prop_type})")
+            
+            # Get the first property from the blueprint for our rule
+            property_name = next(iter(test_blueprint.schema["properties"].keys()))
+            property_type = test_blueprint.schema["properties"][property_name].get("type", "string")
+            
+            print(f"\nSelected property: '{property_name}' (type: {property_type})")
+            
+            # Define a test scorecard with a unique ID using an actual property from the blueprint
+            import uuid
+            import time
+            import json
+            test_id = uuid.uuid4().hex[:8]
+            test_scorecard_id = f"test_scorecard_{test_id}"
+            
+            # Determine property value based on property type
+            if property_type == "number" or property_type == "integer":
+                property_value = 10
+            elif property_type == "boolean":
+                property_value = True
+            else:  # default to string
+                property_value = "test_value"
+                
+            # Define operator based on property type
+            if property_type == "number" or property_type == "integer":
+                property_operator = ">"
+            elif property_type == "boolean":
+                property_operator = "="
+            elif property_type == "array":
+                property_operator = "contains"
+            else:  # default for string and others
+                property_operator = "="
+            
+            test_scorecard_data = {
+                "identifier": test_scorecard_id,
+                "title": "Test Scorecard",
+                "rules": [
+                    {
+                        "identifier": f"test_rule_{test_id}",
+                        "title": f"Test Rule for {property_name}",
+                        "description": f"A test rule using property {property_name}",
+                        "level": "Silver",  # Associate rules with non-base levels
+                        "query": {
+                            "combinator": "and",
+                            "conditions": [
+                                {
+                                    "property": property_name,
+                                    "operator": property_operator,
+                                    "value": property_value
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "levels": [
+                    {
+                        "title": "Basic",  # Base level (no rules)
+                        "color": "blue"
+                    },
+                    {
+                        "title": "Silver",
+                        "color": "silver"
+                    },
+                    {
+                        "title": "Gold", 
+                        "color": "gold"
+                    }
+                ]
+            }
+            
+            # Generate a curl command for debugging
+            formatted_json = json.dumps(test_scorecard_data, indent=2)
+            print(f"\n===== CURL COMMAND FOR DEBUGGING =====")
+            print(f"curl -X POST 'https://api.getport.io/v1/blueprints/{blueprint_id}/scorecards' \\")
+            print(f"-H 'Content-Type: application/json' \\")
+            print(f"-H 'Authorization: Bearer YOUR_ACCESS_TOKEN' \\")
+            print(f"-d '{formatted_json}'")
+            
+            print(f"\nCreating test scorecard with ID '{test_scorecard_id}' for blueprint '{blueprint_id}'")
+            print(f"Full Scorecard Data: {json.dumps(test_scorecard_data, indent=2)}")
+            
+            # Create the scorecard
+            try:
+                created_scorecard = await client.create_new_scorecard(blueprint_id, test_scorecard_data)
+                
+                # Validate the response
+                assert isinstance(created_scorecard, PortScorecard)
+                assert created_scorecard.identifier == test_scorecard_id
+                assert created_scorecard.title == "Test Scorecard"
+                assert created_scorecard.blueprint == blueprint_id
+                assert len(created_scorecard.rules) == 1
+                assert len(created_scorecard.levels) == 3
+                
+                print(f"Successfully created scorecard: {created_scorecard.title} (ID: {created_scorecard.identifier})")
+                
+                # Now retrieve the scorecard to verify it exists
+                retrieved_scorecard = await client.get_scorecard_details(test_scorecard_id, blueprint_id)
+                assert isinstance(retrieved_scorecard, PortScorecard)
+                assert retrieved_scorecard.identifier == test_scorecard_id
+                
+                print(f"Successfully retrieved created scorecard")
+                
+                # Now delete the scorecard
+                deletion_result = await client.delete_scorecard(test_scorecard_id, blueprint_id)
+                assert deletion_result is True, "Deletion should return True on success"
+                
+                print(f"Successfully deleted scorecard")
+                
+                # Try to retrieve the deleted scorecard, should raise an exception
+                try:
+                    await client.get_scorecard_details(test_scorecard_id, blueprint_id)
+                    pytest.fail("Should not be able to retrieve a deleted scorecard")
+                except Exception as retrieval_error:
+                    print(f"Expected error on retrieval after deletion: {str(retrieval_error)}")
+                    # This is the expected behavior
+                    pass
+            except Exception as creation_error:
+                print(f"\n===== ERROR CREATING SCORECARD =====")
+                print(f"Error: {str(creation_error)}")
+                print(f"Full scorecard data: {json.dumps(test_scorecard_data, indent=2)}")
+                print(f"Blueprint ID: {blueprint_id}")
+                
+                # Check if this is a 409 Conflict error
+                if "409 Client Error: Conflict" in str(creation_error):
+                    print("\nThis is a 409 Conflict error, which may indicate:")
+                    print("1. A scorecard with the same ID already exists")
+                    print("2. Permissions don't allow creating scorecards")
+                    print("3. The blueprint doesn't support scorecards")
+                    print("4. There's an issue with the payload format")
+                    
+                    # Generate a curl command for the user to try directly
+                    print("\nPlease try running the curl command above with your access token")
+                    
+                    pytest.skip("Skipping test due to scorecard conflict (409)")
+                # Re-raise other errors
+                raise creation_error
+                
+        except Exception as e:
+            if "409 Client Error: Conflict" not in str(e):
+                print(f"Error in create_and_delete_scorecard test: {str(e)}")
+                import traceback
+                traceback.print_exc()
+                
+                # Try to clean up if creation succeeded but later steps failed
+                try:
+                    await client.delete_scorecard(test_scorecard_id, blueprint_id)
+                    print(f"Cleaned up test scorecard after test failure")
+                except:
+                    pass
+                    
+                pytest.fail(f"Error in scorecard creation/deletion test: {str(e)}")
+
+    @pytest.mark.asyncio
+    async def test_create_scorecard_detailed_error(self, mock_port_client):
+        """Test that detailed error information is included when creating a scorecard fails with a 422 error."""
+        from requests import Response
+        from requests.exceptions import HTTPError
+        
+        # Create a mock response with error details
+        mock_response = Response()
+        mock_response.status_code = 422
+        
+        # Add JSON error response with details
+        error_content = {
+            "message": "Validation failed",
+            "details": "Invalid rule format. Expected 'query' object to contain 'combinator' and 'conditions'."
+        }
+        mock_response._content = json.dumps(error_content).encode('utf-8')
+        
+        # Set up the response to return the JSON content when json() is called
+        mock_response.json = MagicMock(return_value=error_content)
+        
+        # Make the response raise an HTTPError when raise_for_status is called
+        mock_response.raise_for_status = lambda: exec('raise HTTPError("422 Client Error")')
+        
+        # Create the HTTP error with the mock response
+        http_error = HTTPError("422 Client Error")
+        http_error.response = mock_response
+        
+        # Configure create_new_scorecard to raise PortError with the proper error message
+        error_message = f"Error creating scorecard: 422 - {error_content['message']}. Details: {error_content['details']}"
+        mock_port_client.create_new_scorecard.side_effect = PortError(error_message)
+        
+        # Attempt to create a scorecard
+        blueprint_id = "test-blueprint"
+        scorecard_data = {
+            "identifier": "test-scorecard",
+            "title": "Test Scorecard",
+            "levels": [{"title": "Basic", "color": "green"}],
+            "rules": []
+        }
+        
+        # Verify that the error contains the detailed information
+        with pytest.raises(PortError) as exc_info:
+            await mock_port_client.create_new_scorecard(blueprint_id, scorecard_data)
+        
+        error_message = str(exc_info.value)
+        assert "422" in error_message
+        assert "Validation failed" in error_message
+        assert "Invalid rule format" in error_message
+        assert "combinator" in error_message 

--- a/tests/client/test_scorecards_mock.py
+++ b/tests/client/test_scorecards_mock.py
@@ -1,0 +1,159 @@
+import pytest
+import sys
+
+# Add the src directory to the path so we can import our modules
+sys.path.append('src')
+
+from mcp_server_port.models.models import PortScorecardList, PortScorecard
+from .fixtures.scorecards import MOCK_SCORECARDS_DATA
+
+class TestPortScorecardClientMock:
+    """Tests for the Port Scorecard Client functionality using mocks."""
+
+    @pytest.mark.asyncio
+    async def test_get_scorecards_mock(self, mock_client):
+        """Test getting all scorecards with mocked data."""
+        print("\nTesting get_scorecards with mock data")
+        
+        # Get scorecards with mocked data
+        scorecard_list = await mock_client.get_all_scorecards()
+        
+        # Validate the response
+        assert isinstance(scorecard_list, PortScorecardList)
+        assert isinstance(scorecard_list.scorecards, list)
+        assert len(scorecard_list.scorecards) == len(MOCK_SCORECARDS_DATA)
+        
+        # Validate each scorecard
+        for i, scorecard in enumerate(scorecard_list.scorecards):
+            mock_scorecard = MOCK_SCORECARDS_DATA[i]
+            assert isinstance(scorecard, PortScorecard)
+            assert scorecard.identifier == mock_scorecard["identifier"]
+            assert scorecard.title == mock_scorecard["title"]
+            assert scorecard.blueprint == mock_scorecard["blueprint"]
+            
+            # Check rules if present
+            if "rules" in mock_scorecard:
+                assert len(scorecard.rules) == len(mock_scorecard["rules"])
+            
+            # Check levels if present
+            if "levels" in mock_scorecard:
+                assert len(scorecard.levels) == len(mock_scorecard["levels"])
+
+    @pytest.mark.asyncio
+    async def test_get_scorecard_mock(self, mock_client):
+        """Test getting a specific scorecard by identifier with mocked data."""
+        # Test getting each scorecard from our mock data
+        for mock_scorecard in MOCK_SCORECARDS_DATA:
+            scorecard_id = mock_scorecard["identifier"]
+            blueprint_id = mock_scorecard["blueprint"]
+            print(f"\nTesting get_scorecard with ID: {scorecard_id} and blueprint: {blueprint_id}")
+            
+            # Get the specific scorecard
+            scorecard = await mock_client.get_scorecard_details(scorecard_id, blueprint_id)
+            
+            # Validate the response
+            assert isinstance(scorecard, PortScorecard)
+            assert scorecard.identifier == scorecard_id
+            assert scorecard.blueprint == blueprint_id
+            assert scorecard.title == mock_scorecard["title"]
+            
+            # Check rules if present
+            if "rules" in mock_scorecard:
+                assert len(scorecard.rules) == len(mock_scorecard["rules"])
+                
+                # Validate the first rule if available
+                if mock_scorecard["rules"]:
+                    first_mock_rule = mock_scorecard["rules"][0]
+                    first_actual_rule = scorecard.rules[0]
+                    assert first_actual_rule["identifier"] == first_mock_rule["identifier"]
+                    assert first_actual_rule["title"] == first_mock_rule["title"]
+            
+            # Check levels if present
+            if "levels" in mock_scorecard:
+                assert len(scorecard.levels) == len(mock_scorecard["levels"])
+                
+                # Validate the first level if available
+                if mock_scorecard["levels"]:
+                    first_mock_level = mock_scorecard["levels"][0]
+                    first_actual_level = scorecard.levels[0]
+                    assert first_actual_level["title"] == first_mock_level["title"]
+                    assert first_actual_level["color"] == first_mock_level["color"]
+    
+    @pytest.mark.asyncio
+    async def test_create_and_delete_scorecard_mock(self, mock_client):
+        """Test creating a new scorecard and then deleting it with mocked data."""
+        print("\nTesting create_and_delete_scorecard with mock data")
+        
+        # Define a test blueprint ID
+        test_blueprint_id = "test_blueprint"
+        
+        # Create a test scorecard data
+        test_scorecard_data = {
+            "identifier": "test_scorecard_mock",
+            "title": "Test Scorecard Mock",
+            "rules": [
+                {
+                    "identifier": "test_rule_mock",
+                    "title": "Test Rule for Mock",
+                    "description": "A test rule for mock testing",
+                    "level": "Silver",  # Associate rules with non-base levels
+                    "query": {
+                        "combinator": "and",
+                        "conditions": [
+                            {
+                                "property": "status",
+                                "operator": "=",
+                                "value": "active"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "levels": [
+                {
+                    "title": "Basic",  # Base level (no rules)
+                    "color": "blue"
+                },
+                {
+                    "title": "Silver",
+                    "color": "silver"
+                },
+                {
+                    "title": "Gold",
+                    "color": "gold"
+                }
+            ]
+        }
+        
+        # Create the scorecard
+        created_scorecard = await mock_client.create_new_scorecard(test_blueprint_id, test_scorecard_data)
+        
+        # Validate the response
+        assert isinstance(created_scorecard, PortScorecard)
+        assert created_scorecard.identifier == "test_scorecard_mock"
+        assert created_scorecard.title == "Test Scorecard Mock"
+        assert len(created_scorecard.rules) == 1
+        assert len(created_scorecard.levels) == 3
+        
+        # We need to add the test scorecard to our mock data for deletion to work
+        from .fixtures.scorecards import MOCK_SCORECARDS_DATA
+        
+        # Create a proper mock scorecard entry
+        mock_scorecard_entry = {
+            "identifier": "test_scorecard_mock",
+            "title": "Test Scorecard Mock",
+            "blueprint": test_blueprint_id,
+            "rules": test_scorecard_data["rules"],
+            "levels": test_scorecard_data["levels"],
+        }
+        
+        # Add it to the mock data
+        MOCK_SCORECARDS_DATA.append(mock_scorecard_entry)
+        
+        try:
+            # Delete the scorecard
+            deletion_result = await mock_client.delete_scorecard("test_scorecard_mock", test_blueprint_id)
+            assert deletion_result is True
+        finally:
+            # Clean up mock data
+            MOCK_SCORECARDS_DATA.remove(mock_scorecard_entry) 


### PR DESCRIPTION
This PR introduces capabilities to interact with Port Scorecards via the MCP server. 

It adds new tools (get_scorecards, get_scorecard, create_scorecard) and updates the README.md to reflect these changes.